### PR TITLE
Fix incorrect rgl log files being attached to reports.

### DIFF
--- a/ErrorWindow.vb
+++ b/ErrorWindow.vb
@@ -268,6 +268,7 @@ Public Class ErrorWindow
                                                                 Dim reg = New Regex("rgl_log_([0-9])*\.txt")
                                                                 Return reg.Match(x.Name).Success
                                                             End Function) _
+                                                     .OrderByDescending(Function(x) x.LastWriteTimeUtc) _
                                                      .FirstOrDefault()
         If temptFile IsNot Nothing Then
             Dim filestrm As New FileStream(temptFile.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)


### PR DESCRIPTION
Added sorting for rgl logs by their last modification date so the most recent of the 5 rgl logs is used as that would be the one which corresponds to a crash that just occurred.

Bannerlord 1.3 added support for 5 rolling rgl logs instead of a single log that is constantly overwritten on each game launch.


Minor note : 
GetGameLogDateTime doesn't use the regex pattern, but instead just looks for "rgl_log_". This probably doesn't cause issues because the "rgl_log_errors..." files and the "rgl_log_#" ones are probably being written to at almost the same time and so the time on the "rgl_log_#" will usually be the more recent one, or sufficiently close.